### PR TITLE
Switch from Firefox to Chromium for CI tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install browser
-        run: sudo apt-get install firefox
+        run: sudo apt-get install chromium-chromedriver
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install browser
-        run: sudo apt-get install firefox
+        run: sudo apt-get install chromium-chromedriver
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "webpack --mode=development",
     "build-production": "webpack --mode=production",
-    "ci-test": "karma start --browsers FirefoxHeadless --single-run",
+    "ci-test": "CHROME_BIN=/usr/bin/chromium-browser karma start --browsers ChromeHeadless --single-run",
     "lint": "eslint *.js; eslint src; eslint spec",
     "start": "webpack serve --open",
     "test": "karma start --single-run",


### PR DESCRIPTION
On the latest Ubuntu Firefox is installed as a snap and so doesn't work easily in a way that can be controlled by Karma.